### PR TITLE
Proper child level counting, and _mouseStop fallback.

### DIFF
--- a/jquery.ui.nestedSortable.js
+++ b/jquery.ui.nestedSortable.js
@@ -131,7 +131,6 @@
 
 			this.beyondMaxLevels = 0;
 
-			$(this.placeholder[0]).html('level ' + level + ', child levels ' + childLevels);
 			// If the item is moved to the left, send it to its parent level
 			if (parentItem != null && this.positionAbs.left < parentItem.offset().left) {
 				parentItem.after(this.placeholder[0]);

--- a/jquery.ui.nestedSortable.js
+++ b/jquery.ui.nestedSortable.js
@@ -131,6 +131,7 @@
 
 			this.beyondMaxLevels = 0;
 
+			$(this.placeholder[0]).html('level ' + level + ', child levels ' + childLevels);
 			// If the item is moved to the left, send it to its parent level
 			if (parentItem != null && this.positionAbs.left < parentItem.offset().left) {
 				parentItem.after(this.placeholder[0]);
@@ -168,12 +169,20 @@
 
 			// If the item is in a position not allowed, send it back
 			if (this.beyondMaxLevels) {
-				var parent = this.placeholder[0].parentNode.parentNode;
-				for (var i = this.beyondMaxLevels-1; i > 0; i--) {
-					parent = parent.parentNode.parentNode;
+				var placeholder_element = $(this.placeholder[0]);
+				var parent = placeholder_element.parent().closest('li');
+
+				for (var i = this.beyondMaxLevels - 1; i > 0; i--) {
+					parent = parent.parent().closest('li');
+
 				}
+				
 				this.placeholder.removeClass(this.options.errorClass);
-				$(parent).after(this.placeholder[0]);
+				if(!parent.attr('tagName') || parent.attr('tagName').toLowerCase() != 'li') {
+					parent = placeholder_element.parents('li').last();
+				}
+				parent.after(placeholder_element);
+			
 				this._trigger("change", event, this._uiHash());
 			}
 
@@ -313,12 +322,19 @@
 
 				return level;
 		},
+		
+		_getChildLevels: function(parent, depth) {
+			var self = this;
+			var result = 0;
+			var depth = depth || 0;
+			
+			$(parent).children('ol').children(this.options.items).each(
+				function(index, child) {
+					result = Math.max(self._getChildLevels(child, depth + 1), result);
+				}
+			);
 
-		_getChildLevels: function(item) {
-
-				levels = item.find(this.options.items).filter(this.options.items+':first-child').length;
-
-				return levels;
+			return depth ? result + 1 : result;
 		},
 
 		_isAllowed: function(parentItem, levels) {
@@ -341,5 +357,4 @@
 	}));
 
 	$.ui.nestedSortable.prototype.options = $.extend({}, $.ui.sortable.prototype.options, $.ui.nestedSortable.prototype.options);
-
 })(jQuery);


### PR DESCRIPTION
Fixed a major issue where the depth of a list item's subtree was miscalculated (with the `_getChildLevels(...)` method). This meant that occasionally top-level elements would be kicked out of their `<ol>` list container because they'd exceed their nestedSortable's max levels, which was _pretty_ broken.

As an example, this configuration would not be accepted if the max levels were 3, because the depth of this subtree was miscalculated as 4, instead of 3:

```
* A
  * B
    * C
  * D
    * E
```

This was considered depth 5:

```
* A
  * B
    * C
  * D
    * E
  * F
    * G
```

So as you can see, using `:first-child` is not the correct way to check for the depth of the DOM tree. I made this a recursive DOM traversal instead, and it works. I don't imagine that performance will be hurt too much.

Also added a fallback to the `_mouseStop` function such that it should be less likely to accidentally insert outside the sortable list.

These fixes should hopefully improve the usability of this plugin.

Thanks,

-- Andrew G. Crowell
