### PR TITLE
Fixed a bug and made two UX improvements.

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -135,7 +135,7 @@
 			    previousItem = this.placeholder[0].previousSibling ? $(this.placeholder[0].previousSibling) : null;
 
 			if (previousItem != null) {
-				while (previousItem[0].nodeName.toLowerCase() != 'li' || previousItem[0] == this.currentItem[0]) {
+				while (previousItem[0].nodeName.toLowerCase() != 'li' || previousItem[0] == this.currentItem[0] || previousItem[0] == this.helper[0]) {
 					if (previousItem[0].previousSibling) {
 						previousItem = $(previousItem[0].previousSibling);
 					} else {

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -131,9 +131,10 @@
 				       			? $(this.placeholder[0].parentNode.parentNode)
 				       			: null,
 			    level = this._getLevel(this.placeholder),
-			    childLevels = this._getChildLevels(this.helper),
-			    previousItem = this.placeholder[0].previousSibling ? $(this.placeholder[0].previousSibling) : null;
+			    childLevels = this._getChildLevels(this.helper);
 
+      // To find the previous sibling in the list, keep backtracking until we hit a valid list item.
+			var previousItem = this.placeholder[0].previousSibling ? $(this.placeholder[0].previousSibling) : null;
 			if (previousItem != null) {
 				while (previousItem[0].nodeName.toLowerCase() != 'li' || previousItem[0] == this.currentItem[0] || previousItem[0] == this.helper[0]) {
 					if (previousItem[0].previousSibling) {
@@ -145,19 +146,32 @@
 				}
 			}
 
+      // To find the next sibling in the list, keep stepping forward until we hit a valid list item.
+      var nextItem = this.placeholder[0].nextSibling ? $(this.placeholder[0].nextSibling) : null;
+      if (nextItem != null) {
+        while (nextItem[0].nodeName.toLowerCase() != 'li' || nextItem[0] == this.currentItem[0] || nextItem[0] == this.helper[0]) {
+          if (nextItem[0].nextSibling) {
+            nextItem = $(nextItem[0].nextSibling);
+          } else {
+            nextItem = null;
+            break;
+          }
+        }
+      }
+
 			var newList = document.createElement(o.listType);
 
 			this.beyondMaxLevels = 0;
 			
-			// If the item is moved to the left, send it to its parent level
-			if (parentItem != null &&
+			// If the item is moved to the left, send it to its parent's level unless there are siblings below it.
+			if (parentItem != null && nextItem == null &&
 					(o.rtl && (this.positionAbs.left + this.helper.outerWidth() > parentItem.offset().left + parentItem.outerWidth()) ||
 					!o.rtl && (this.positionAbs.left < parentItem.offset().left))) {
 				parentItem.after(this.placeholder[0]);
 				this._clearEmpty(parentItem[0]);
 				this._trigger("change", event, this._uiHash());
 			}
-			// If the item is below another one and is moved to the right, make it a children of it
+			// If the item is below a sibling and is moved to the right, make it a child of that sibling.
 			else if (previousItem != null &&
 						(o.rtl && (this.positionAbs.left + this.helper.outerWidth() < previousItem.offset().left + previousItem.outerWidth() - o.tabSize) ||
 						!o.rtl && (this.positionAbs.left > previousItem.offset().left + o.tabSize))) {

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -89,6 +89,9 @@
 			//Regenerate the absolute position used for position checks
 			this.positionAbs = this._convertPositionTo("absolute");
 
+      // Find the top offset before rearrangement,
+      var previousTopOffset = this.placeholder.offset().top;
+
 			//Set the helper position
 			if(!this.options.axis || this.options.axis != "y") this.helper[0].style.left = this.position.left+'px';
 			if(!this.options.axis || this.options.axis != "x") this.helper[0].style.top = this.position.top+'px';
@@ -179,7 +182,14 @@
 				if (!previousItem.children(o.listType).length) {
 					previousItem[0].appendChild(newList);
 				}
-				previousItem.children(o.listType)[0].appendChild(this.placeholder[0]);
+        // If this item is being moved from the top, add it to the top of the list.
+        if (previousTopOffset && (previousTopOffset <= previousItem.offset().top)) {
+          previousItem.children(o.listType).prepend(this.placeholder);
+        }
+        // Otherwise, add it to the bottom of the list.
+        else {
+				  previousItem.children(o.listType)[0].appendChild(this.placeholder[0]);
+        }
 				this._trigger("change", event, this._uiHash());
 			}
 			else {


### PR DESCRIPTION
BUG: Sortable helper was being counted as a sibling item in some situations.
UX FIX #1: Preventing accidental dragging of an item to the left.
UX FIX #2: Allowing items that have been dragged up a list to be dragged back down without skipping to the bottom.
