### PR TITLE
Additional functionality for constraining where nodes may be dropped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_store

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Also, the default list type is `<ol>`.
 	<dd>The class given to the placeholder in case of error. Default: <b>ui-nestedSortable-error</b></dd>
 	<dt>listType</dt>
 	<dd>The list type used (ordered or unordered). Default: <b>ol</b></dd>
+	<dt>keepInParent</dt>
+	<dd>Whether to force nodes be sorted only within their original parent. Default: <b>false</b></dd>
+	<dt>maintainNestingLevel</dt>
+  <dd>Whether nodes should be forced to stay within their original nesting level. Default: <b>false</b></dd>
 	<dt>maxLevels</dt>
 	<dd>The maximum depth of nested items the list can accept. If set to '0' the levels are unlimited. Default: <b>0</b></dd>
 	<dt>protectRoot</dt>
@@ -64,6 +68,8 @@ Also, the default list type is `<ol>`.
 	<dd>Set this to true if you have a right-to-left page. Default: <b>false</b></dd>
 	<dt>isAllowed (function)</dt>
 	<dd>You can specify a custom function to verify if a drop location is allowed. Default: <b>function(item, parent) { return true; }</b></dd>
+	<dt>showErrorDiv</dt>
+	<dd>Whether a failed isAllowed method shows a placeholder with the error class or shows no change at all. Default: <b>true</b></dd>
 </dl>
 
 ## Custom Methods

--- a/example/index.html
+++ b/example/index.html
@@ -69,6 +69,10 @@
 			color:#8a1f11;
 		}
 
+    .mjs-nestedSortable-error {
+      background: red;
+    }
+
 		ol {
 			margin: 0;
 			padding: 0;
@@ -472,7 +476,14 @@ setName[n] =>
 			revert: 250,
 			tabSize: 25,
 			tolerance: 'pointer',
-			toleranceElement: '> div'
+			toleranceElement: '> div',
+      protectRoot: false,
+      keepInContainer: false,
+      maintainNestingLevel: false,
+      showErrorDiv: false,
+      isAllowed: function(parent, item) {
+        return false;
+      }
 		});
 
 		$('#serialize').click(function(){

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -26,7 +26,7 @@
 			rtl: false,
             maintainNestingLevel: false, // if true, you can not move nodes to different levels of nesting
             showErrorDiv: true, // show the error div or just not show a drop area
-            keepInContainer: false, // if true only allows you to rearrange within its parent container
+            keepInParent: false, // if true only allows you to rearrange within its parent container
 			isAllowed: function(item, parent) { return true; }
 		},
 
@@ -109,7 +109,7 @@
 					&&	this.placeholder[intersection == 1 ? "next" : "prev"]()[0] != itemElement //no useless actions that have been done before
 					&&	!$.contains(this.placeholder[0], itemElement) //no action if the item moved is the parent of the item checked
 					&& (this.options.type == 'semi-dynamic' ? !$.contains(this.element[0], itemElement) : true)
-					&& (!o.keepInContainer || itemElement.parentNode == this.placeholder[0].parentNode) // only rearrange items within the same container
+					&& (!o.keepInParent || itemElement.parentNode == this.placeholder[0].parentNode) // only rearrange items within the same container
                     && (!o.maintainNestingLevel || (this._getLevel(this.currentItem) === this._getLevel($(itemElement)))) // maintain the nesting level of node
                     && (o.showErrorDiv || o.isAllowed(itemElement.parentNode, this.currentItem[0]))
 				) {


### PR DESCRIPTION
Added option 'keepInContainer' to only allow nodes to be sorted within their original parent.

Added option 'maintainNestingLevel' to only allow nodes to be placed at the same nesting level as where they started.

Added option 'showErrorDiv' which decides whether a failed isAllowed() method shows an error placeholder or shows no change at all.

isAllowed() now takes the current item instead of the current placeholder.

I hope these changes may help :)
