### PR TITLE
Fix isAllowed call (current item instead of placeholder)

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -403,7 +403,7 @@
 			// Is the root protected?
 			// Are we trying to nest under a no-nest?
 			// Are we nesting too deep?
-			if (!o.isAllowed(this.placeholder, parentItem) ||
+			if (!o.isAllowed(this.currentItem, parentItem) ||
 				parentItem && parentItem.hasClass(o.disableNesting) ||
 				o.protectRoot && (parentItem == null && !isRoot || isRoot && level > 1)) {
 					this.placeholder.addClass(o.errorClass);


### PR DESCRIPTION
Referring to the discussion about commit [c1d6a86](https://github.com/mjsarfatti/nestedSortable/commit/c1d6a863a66636c5b27c9abe25178dca62443ba7), isAllowed should be called with the currentItem instead of the item's placeholder, which is pretty useless.
