### PR TITLE
Replaced non working URL in source code header

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -1,7 +1,7 @@
 /*
  * jQuery UI Nested Sortable
  * v 1.3.5 / 21 jun 2012
- * http://mjsarfatti.com/code/nestedSortable
+ * http://github.com/mjsarfatti/nestedSortable/
  *
  * Depends on:
  *	 jquery.ui.sortable.js 1.8+


### PR DESCRIPTION
I really like to be able to track the locations of files that I include in my projects and I noticed this link wasn't working. The GitHub link is likely to be more durable.
