### PR TITLE
Fix toHierarchy(), jquery (1.7.2|1.8.0|1.8.3|1.9.1|2.0.0) tested done.

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -448,6 +448,7 @@
 		},
 
 		toHierarchy: function(options) {
+
 			var o = $.extend({}, this.options, options),
 				sDepth = o.startDepthCount || 0,
 			    ret = [];
@@ -476,6 +477,7 @@
 
 				return ret;
 			}
+
 		},
 
 		toArray: function(options) {

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -448,31 +448,33 @@
 		},
 
 		toHierarchy: function(options) {
-
 			var o = $.extend({}, this.options, options),
 				sDepth = o.startDepthCount || 0,
 			    ret = [];
 
-			$(this.element).children(o.items).each(function () {
-				var level = _recursiveItems(this);
-				ret.push(level);
-			});
+			var elems = $(this.element).children(o.items);
 
-			return ret;
+			return _recursiveItems(elems);
 
-			function _recursiveItems(item) {
-				var id = ($(item).attr(o.attribute || 'id') || '').match(o.expression || (/(.+)[-=_](.+)/));
-				if (id) {
-					var currentItem = {"id" : id[2]};
-					if ($(item).children(o.listType).children(o.items).length > 0) {
-						currentItem.children = [];
-						$(item).children(o.listType).children(o.items).each(function() {
-							var level = _recursiveItems(this);
-							currentItem.children.push(level);
-						});
+			function _recursiveItems(items) {
+				var ret = [];
+
+				items.each(function() {
+					var id = ($(this).attr(o.attribute || 'id') || '');
+
+					if (id) {
+						var currentItem = { id : id };
+						var children = $(this).children(o.listType).children(o.items);
+
+						if (children.length != 0) {
+							currentItem.children = _recursiveItems(children);
+						}
+
+						return ret.push(currentItem);
 					}
-					return currentItem;
-				}
+				});
+
+				return ret;
 			}
 		},
 

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -449,9 +449,7 @@
 
 		toHierarchy: function(options) {
 
-			var o = $.extend({}, this.options, options),
-			    ret = [];
-
+			var o = $.extend({}, this.options, options);
 			var elems = $(this.element).children(o.items);
 
 			return _recursiveItems(elems);

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -450,7 +450,6 @@
 		toHierarchy: function(options) {
 
 			var o = $.extend({}, this.options, options),
-				sDepth = o.startDepthCount || 0,
 			    ret = [];
 
 			var elems = $(this.element).children(o.items);


### PR DESCRIPTION
".match(o.expression ...)" not need (like ui.sortable toArray()).
