### PR TITLE
toArray added option excludeRoot

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -481,15 +481,18 @@
 			var o = $.extend({}, this.options, options),
 				sDepth = o.startDepthCount || 0,
 			    ret = [],
-			    left = 2;
+			    left = 1;
 
-			ret.push({
-				"item_id": o.rootID,
-				"parent_id": 'none',
-				"depth": sDepth,
-				"left": '1',
-				"right": ($(o.items, this.element).length + 1) * 2
-			});
+			if (!o.excludeRoot) {
+				ret.push({
+					"item_id": o.rootID,
+					"parent_id": null,
+					"depth": sDepth,
+					"left": left,
+					"right": ($(o.items, this.element).length + 1) * 2
+				});
+				left++
+			}
 
 			$(this.element).children(o.items).each(function () {
 				left = _recursiveArray(this, sDepth + 1, left);


### PR DESCRIPTION
Not in all cases a Nested Set was one root item.
This patch adds a `excludeRoot` option to the `toArray` function to allow a this.

Other minor tweaks are:
- make the root item use a Number `left` not a string
- make the root item use `parent_id: null` since this is the default behavior when using the `excludeRoot` option (and in my opinion is more logical then `'none'`)
