### PR TITLE
Expanding output object when using toHierarchy

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -284,6 +284,7 @@
 
 			function _recursiveItems(item) {
 				var dataItems = [];
+				
 				$(item).data().each(function(index, value) {
 					dataItems[index] = value;
 				});
@@ -291,9 +292,11 @@
 				var id = ($(item).attr(o.attribute || 'id') || '').match(o.expression || (/(.+)[-=_](.+)/));
 				if (id) {
 					var currentItem = {"id" : id[2]};
-					$.each(dataItems, function(index, value) {
-						currentItem[index] = value;
-					});
+
+					for(var prop in dataItems) {
+						currentItem[prop] = dataItems[prop]
+					}
+
 					if ($(item).children(o.listType).children(o.items).length > 0) {
 						currentItem.children = [];
 						$(item).children(o.listType).children(o.items).each(function() {

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -283,9 +283,17 @@
 			return ret;
 
 			function _recursiveItems(item) {
+				var dataItems = [];
+				$(item).data().each(function(index, value) {
+					dataItems[index] = value;
+				});
+
 				var id = ($(item).attr(o.attribute || 'id') || '').match(o.expression || (/(.+)[-=_](.+)/));
 				if (id) {
 					var currentItem = {"id" : id[2]};
+					$.each(dataItems, function(index, value) {
+						currentItem[index] = value;
+					});
 					if ($(item).children(o.listType).children(o.items).length > 0) {
 						currentItem.children = [];
 						$(item).children(o.listType).children(o.items).each(function() {


### PR DESCRIPTION
My team needed a bit more information on the objects that we were sorting.  We did this through data attributes on the li's.  We thought it would be real nice to add that information automatically to the output object on toHierarchy.  We thought other people might think it convenient as well.

All we did for was add a $.each().data() loop on the item passed into "toHierarchy".  We can then loop through the captured items and add them to the currentItem object as properties.

Loving nestedSortable so far.  It is working really well for us.  Thanks!
