### PR TITLE
Added ability to skip items with disabledClass.  Useful when sorting over disabled or hidden items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Also, the default list type is `<ol>`.
 	<dd>Given to collapsed branches when dragging an item over them. Default: <b>mjs-nestedSortable-hovering</b></dd>
 	<dt>leafClass (2.0)<dt>
 	<dd>Given to items that do not have children. Default: <b>mjs-nestedSortable-leaf</b></dd>
+	<dt>disabledClass (2.0)<dt>
+	<dd>Given to items that should be skipped when sorting over them. For example, non-visible items that are still part of the list. Default: <b>mjs-nestedSortable-disabled</b></dd>
 </dl>
 
 ## Custom Methods

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -38,7 +38,8 @@
 			errorClass: 'mjs-nestedSortable-error',
 			expandedClass: 'mjs-nestedSortable-expanded',
 			hoveringClass: 'mjs-nestedSortable-hovering',
-			leafClass: 'mjs-nestedSortable-leaf'
+			leafClass: 'mjs-nestedSortable-leaf',
+			disabledClass: 'mjs-nestedSortable-disabled'
 		},
 
 		_create: function() {
@@ -257,7 +258,7 @@
 			// mjs - to find the previous sibling in the list, keep backtracking until we hit a valid list item.
 			var previousItem = this.placeholder[0].previousSibling ? $(this.placeholder[0].previousSibling) : null;
 			if (previousItem != null) {
-				while (previousItem[0].nodeName.toLowerCase() != 'li' || previousItem[0] == this.currentItem[0] || previousItem[0] == this.helper[0]) {
+				while (previousItem[0].nodeName.toLowerCase() != 'li' || previousItem[0].className.indexOf(o.disabledClass) !== -1 || previousItem[0] == this.currentItem[0] || previousItem[0] == this.helper[0]) {
 					if (previousItem[0].previousSibling) {
 						previousItem = $(previousItem[0].previousSibling);
 					} else {
@@ -270,7 +271,7 @@
 			// mjs - to find the next sibling in the list, keep stepping forward until we hit a valid list item.
 			var nextItem = this.placeholder[0].nextSibling ? $(this.placeholder[0].nextSibling) : null;
 			if (nextItem != null) {
-				while (nextItem[0].nodeName.toLowerCase() != 'li' || nextItem[0] == this.currentItem[0] || nextItem[0] == this.helper[0]) {
+				while (nextItem[0].nodeName.toLowerCase() != 'li' || nextItem[0].className.indexOf(o.disabledClass) !== -1 || nextItem[0] == this.currentItem[0] || nextItem[0] == this.helper[0]) {
 					if (nextItem[0].nextSibling) {
 						nextItem = $(nextItem[0].nextSibling);
 					} else {

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -179,6 +179,27 @@
 					continue;
 				}
 
+				// No action if intersected item is disabled 
+				// and the element above or below in the direction we're going is also disabled
+				if (itemElement.className.indexOf(o.disabledClass) !== -1) {
+					// Note: intersection hardcoded direction values from jquery.ui.sortable.js:_intersectsWithPointer
+					if (intersection === 2) {
+						// Going down
+						var itemAfter = this.items[i + 1];
+						if (itemAfter && itemAfter.item[0].className.indexOf(o.disabledClass) !== -1){
+							continue;
+						}
+						
+					}
+					else if (intersection === 1) {
+						// Going up
+						var itemBefore = this.items[i - 1];
+						if (itemBefore && itemBefore.item[0].className.indexOf(o.disabledClass) !== -1){
+							continue;
+						}
+					}
+				}
+
 				// cannot intersect with itself
 				// no useless actions that have been done before
 				// no action if the item moved is the parent of the item checked


### PR DESCRIPTION
Items with the class specified by the disabledClass option will be skipped when sorting another item over them.

This is useful if you have a nested list where some items can be disabled/hidden but you still need to be able to properly sort over them. Without this feature sorting over hidden items behaves erratically when changing nesting levels.

Thanks!
