### PR TITLE
Allows starting individual branches expanded or collapsed

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -63,8 +63,10 @@
 					if ($li.children(self.options.listType).length) {
 						$li.addClass(self.options.branchClass);
 						// expand/collapse class only if they have children
-						if (self.options.startCollapsed) $li.addClass(self.options.collapsedClass);
-						else $li.addClass(self.options.expandedClass);
+						if ( ! $li.hasClass( self.options.collapsedClass ) && ( ! $li.hasClass( self.options.expandedClass ) ) ) {
+							if (self.options.startCollapsed) $li.addClass(self.options.collapsedClass);
+							else $li.addClass(self.options.expandedClass);
+						}
 					} else {
 						$li.addClass(self.options.leafClass);
 					}


### PR DESCRIPTION
This update allows you to explicitly define the starting state of individual branches to be either expanded or collapsed beyond the default starting state of all collapsed or all expended. This allows overriding the default startCollapsed option on a per-branch level as needed.

On any branches you wish to start as explicitly collapsed or expanded, simply apply your defined (or default if you did not define) expandedClass or collapsedClass classname to the applicable <li> branch (or whatever you are using as your defined entity in the "items" setting).

I needed this so that I could ‘remember’ the state of individual branches and restore them on page load.
